### PR TITLE
feat: logic to use chat history is complete

### DIFF
--- a/backend/routes/agent_chat.py
+++ b/backend/routes/agent_chat.py
@@ -16,7 +16,7 @@ async def chat_with_agent(
     current_user: User = Depends(get_current_user)
 ):
     try:
-        response = await run_agent(payload.message, current_user.id)
+        response = await run_agent(payload.history, payload.question, current_user.id)
         return AgentChatResponse(status="success", response=response)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))

--- a/backend/schemas/agent_chat.py
+++ b/backend/schemas/agent_chat.py
@@ -1,8 +1,10 @@
 # schemas/agent_chat.py
 from pydantic import BaseModel
+from typing import List, Dict
 
 class AgentChatRequest(BaseModel):
-    message: str
+    history: List[Dict[str, str]]
+    question: str
 
 class AgentChatResponse(BaseModel):
     status: str

--- a/backend/services/agents/agent_runner.py
+++ b/backend/services/agents/agent_runner.py
@@ -1,10 +1,10 @@
 # services/agents/agent_runner.py
 
 import os
-from typing import Optional
+from typing import Optional, List, Dict
 
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage, AIMessage
 from services.agents.prompts import SYSTEM_PROMPT
 from services.agents.tools import TOOLS
 
@@ -18,16 +18,26 @@ llm = ChatOpenAI(
     openai_api_key=os.getenv("OPENAI_API_KEY")
 ).bind_tools(TOOLS)
 
-async def run_agent(user_query: str, user_id: Optional[str] = None) -> str:
+def convert_history_to_langchain(history: List[Dict[str, str]]) -> List:
+    message_map = {
+        "user": HumanMessage,
+        "assistant": AIMessage,
+        "system": SystemMessage
+    }
+    return [message_map[msg["role"]](content=msg["content"]) for msg in history]
+
+async def run_agent(
+    history: List[Dict[str, str]],
+    question: str,
+    user_id: Optional[str] = None
+) -> str:
     system = SystemMessage(content=SYSTEM_PROMPT)
-    user = HumanMessage(content=user_query)
+    messages = [system] + convert_history_to_langchain(history) + [HumanMessage(content=question)]
 
     # First step: ask the LLM what it wants to do
-    response = await llm.ainvoke([system, user])
+    response = await llm.ainvoke(messages)
 
-    # Check if it requested a tool
     tool_calls = response.additional_kwargs.get("tool_calls", [])
-    
     if not tool_calls:
         return response.content
 
@@ -36,14 +46,12 @@ async def run_agent(user_query: str, user_id: Optional[str] = None) -> str:
         tool_name = call["function"]["name"]
         args = call["function"]["arguments"]
 
-        # Find the tool
         tool_fn = TOOL_MAP.get(tool_name)
         if not tool_fn:
             continue
 
         try:
             parsed_args = eval(args) if isinstance(args, str) else args
-            #if user_id:
             parsed_args["user_id"] = str(user_id)
             result = tool_fn.run(parsed_args)
         except Exception as e:
@@ -52,6 +60,5 @@ async def run_agent(user_query: str, user_id: Optional[str] = None) -> str:
         tool_messages.append(ToolMessage(tool_call_id=call["id"], content=result))
 
     # Final response after tool use
-    final_response = await llm.ainvoke([system, user, response] + tool_messages)
-
+    final_response = await llm.ainvoke(messages + [response] + tool_messages)
     return final_response.content


### PR DESCRIPTION
Added support for using chats sent by the user.

Here is an example payload:

{
  "history": [
    { "role": "user", "content": "What is AAPL doing today?" },
    { "role": "assistant", "content": "AAPL is trending up with 2.5% gains." }
  ],
  "question": "Is it a good time to buy?, Also name the stock I am looking to buy"
}

another example:

{
  "history": [
    { "role": "user", "content": "What is AAPL doing today?" },
    { "role": "assistant", "content": "AAPL is trending up with 2.5% gains." },
    { "role": "user", "content": "Is it a good time to buy?" },
    { "role": "assistant", "content": "Based on your portfolio's technical indicators, it seems like a good time to buy AAPL"}
  ],
  "question": "Buy 2 units worth of AAPL shares at Market Value"
}